### PR TITLE
Improve BuildGradleFilesModifier logic.

### DIFF
--- a/src/main/kotlin/io/embrace/android/intellij/plugin/dataproviders/EmbraceIntegrationDataProvider.kt
+++ b/src/main/kotlin/io/embrace/android/intellij/plugin/dataproviders/EmbraceIntegrationDataProvider.kt
@@ -189,10 +189,10 @@ internal class EmbraceIntegrationDataProvider(
             }
 
             else -> {
-                callback.onGradleFileError("gradleFileError".text())
+                callback.onGradleFileError("noApplicationModule".text())
 
                 trackingService.trackEvent(TrackingEvent.GRADLE_FILE_MODIFICATION_FAILED, buildJsonObject {
-                    put("error", "gradleFileError".text())
+                    put("error", "noApplicationModule".text())
                 })
             }
         }

--- a/src/main/kotlin/io/embrace/android/intellij/plugin/repository/gradle/GradleToolingApiWrapper.kt
+++ b/src/main/kotlin/io/embrace/android/intellij/plugin/repository/gradle/GradleToolingApiWrapper.kt
@@ -2,6 +2,7 @@ package io.embrace.android.intellij.plugin.repository.gradle
 
 import com.android.tools.build.jetifier.core.utils.Log
 import io.embrace.android.intellij.plugin.repository.sentry.SentryLogger
+import org.gradle.tooling.BuildException
 import org.gradle.tooling.GradleConnector
 import org.gradle.tooling.model.GradleProject
 import java.io.File
@@ -21,6 +22,9 @@ internal class GradleToolingApiWrapper(basePath: String) {
                 val buildScript = model.buildScript
                 return buildScript.sourceFile
             }
+        } catch (e: BuildException) {
+            SentryLogger.logException(e)
+            Log.e(TAG, "BuildException: Gradle sync failed. ${e.message}")
         } catch (e: Exception) {
             SentryLogger.logException(e)
             Log.e(TAG, "Error while trying to get build.gradle file: ${e.message}")
@@ -38,6 +42,9 @@ internal class GradleToolingApiWrapper(basePath: String) {
                 else
                     return modules.first().buildScript.sourceFile
             }
+        } catch (e: BuildException) {
+            SentryLogger.logException(e)
+            Log.e(TAG, "BuildException: Gradle sync failed. ${e.message}")
         } catch (e: Exception) {
             SentryLogger.logException(e)
             Log.e(TAG, "Error while trying to get build.gradle file: ${e.message}")
@@ -51,6 +58,9 @@ internal class GradleToolingApiWrapper(basePath: String) {
                 val model = connection.getModel(GradleProject::class.java)
                 return model.children
             }
+        } catch (e: BuildException) {
+            SentryLogger.logException(e)
+            Log.e(TAG, "BuildException: Gradle sync failed. ${e.message}")
         } catch (e: Exception) {
             SentryLogger.logException(e)
             Log.e(TAG, "Error while trying to get build.gradle file: ${e.message}")

--- a/src/main/kotlin/io/embrace/android/intellij/plugin/ui/components/FormComponentManager.kt
+++ b/src/main/kotlin/io/embrace/android/intellij/plugin/ui/components/FormComponentManager.kt
@@ -32,6 +32,13 @@ import javax.swing.JPanel
 import javax.swing.JSeparator
 
 
+/**
+ * This class is responsible for managing the components of the form.
+ * It contains the logic for:
+ * - enabling/disabling the components based on the current step.
+ * - updating the result panels.
+ * - showing/hiding UI components based on the user's actions.
+ */
 internal class FormComponentManager(private val mainPanel: JPanel) {
     private val successIcon = IconLoader.getIcon("/icons/check.svg", FormComponentManager::class.java)
     private val errorIcon = IconLoader.getIcon("/icons/error.svg", FormComponentManager::class.java)

--- a/src/main/resources/messages/messages.properties
+++ b/src/main/resources/messages/messages.properties
@@ -25,16 +25,7 @@ step4Description= Start the Embrace SDK object at the top of your Application cl
 noIdOrTokenError=Invalid app ID or token. The app ID must have 5 characters,\nand the token must have 32 characters.
 replaceConfig=You already have a configuration file in your project. Would you like to replace it?
 btnAddEmbraceStart=Add Embrace Start method
-gradleFileError=Unable to find the necessary build.gradle file in your project. Please check that your project is properly synced with Gradle, or manually include the missing dependency.
-noApplicationModule=Error: No application module detected.\
-    \n\nThis issue might occur when your Android project is not correctly synchronized \
-    or if there's an error in your Gradle configuration. \
-    \n\nSteps to resolve: \
-    \n1. Sync your project with Gradle files. \
-    \n2. Check your Gradle configuration for errors. \
-    \n3. If the problem persists, manually add the necessary configuration as described in step #3. \
-    \n\nRemember to rebuild your project after any changes to your Gradle files. \
-    \n\nIf you still encounter issues after trying the above steps, please reach out for further support.
+noApplicationModule=build.gradle file not found.\n Please, make sure to sync your project with Gradle files and try again.
 buildFilesErrorShort=An error occurred while modifying your build files.
 gradleFilesAlreadyAdded=The Swazzler plugin is already added in your project.
 showChanges=[+] Show Modified Content


### PR DESCRIPTION
Improve BuildGradleFilesModifier logic so it identifies the dependencies block instead of just the word. 
It's highly possible that the `dependencies` word could be used in a comment or in the repositories section. That way the plugin would have found the wrong place to add the classpath. 
Now it searches for a `dependencies {` in order to add the classpath. 

```
buildscript {
    repositories {
        google()
        mavenCentral()
    }
    // add dependencies here
    dependencies {

```