### PR TITLE
Allow to skip "Connect to embrace" on error

### DIFF
--- a/src/main/kotlin/io/embrace/android/intellij/plugin/dataproviders/EmbraceIntegrationDataProvider.kt
+++ b/src/main/kotlin/io/embrace/android/intellij/plugin/dataproviders/EmbraceIntegrationDataProvider.kt
@@ -73,6 +73,9 @@ internal class EmbraceIntegrationDataProvider(
         try {
             startServer(callback)
         } catch (e: Exception) {
+            trackingService.trackEvent(TrackingEvent.DASHBOARD_CONNECTION_FAILED, buildJsonObject {
+                put("error", e.toString())
+            })
             callback.onOnboardConnectedError("Server could not be started")
             return
         }

--- a/src/main/kotlin/io/embrace/android/intellij/plugin/dataproviders/EmbraceIntegrationDataProvider.kt
+++ b/src/main/kotlin/io/embrace/android/intellij/plugin/dataproviders/EmbraceIntegrationDataProvider.kt
@@ -70,7 +70,11 @@ internal class EmbraceIntegrationDataProvider(
     }
 
     fun connectToEmbrace(callback: OnboardConnectionCallback) {
-        startServer(callback)
+        try {
+            startServer(callback)
+        } catch (e: Exception) {
+            callback.onOnboardConnectedError("Server could not be started")
+        }
 
         val url = buildOnboardDashURL()
         Desktop.getDesktop().browse(URI(url))
@@ -205,10 +209,14 @@ internal class EmbraceIntegrationDataProvider(
         repo.addStartToApplicationClass(buildGradleFilesModifier.value?.appPackageName, callback)
     }
 
-    fun verifyIntegration(callback: VerifyIntegrationCallback): Boolean {
-        if (embraceProject == null || embraceProject!!.sessionId == null) {
-            SentryLogger.logMessage("cannot verify integration, embraceProject or session is null")
-            callback.onEmbraceIntegrationError()
+    fun verifyIntegration(callback: VerifyIntegrationCallback, appId: String?): Boolean {
+        if (embraceProject == null) {
+            if (appId != null) {
+                openDashboard(appId)
+            } else {
+                SentryLogger.logMessage("cannot verify integration, embraceProject or session is null")
+                callback.onEmbraceIntegrationError()
+            }
             return false
         }
         verifyEndpoint(callback)
@@ -246,10 +254,11 @@ internal class EmbraceIntegrationDataProvider(
         return ApiService.EMBRACE_CREATE_PROJECT_URL + "?project_name=$projectName&localhost_port=$callbackPort"
     }
 
-    fun openDashboard() {
-        embraceProject?.let {
+    fun openDashboard(appId: String? = null) {
+        val dashboardAppId = embraceProject?.appId ?: appId
+        dashboardAppId?.let {
             try {
-                val url = ApiService.EMBRACE_DASHBOARD_URL.replace("{appId}", it.appId)
+                val url = ApiService.EMBRACE_DASHBOARD_URL.replace("{appId}", it)
                 Desktop.getDesktop().browse(URI(url))
 
                 trackingService.trackEvent(TrackingEvent.OPEN_DASHBOARD_FROM_PLUGIN)
@@ -260,7 +269,7 @@ internal class EmbraceIntegrationDataProvider(
                     put("error", e.message ?: "unknown error")
                 })
             }
-        } ?: SentryLogger.logMessage("cannot open dashboard, embraceProject is null")
+        } ?: SentryLogger.logMessage("cannot open dashboard, no appId provided")
     }
 
     fun getSwazzlerClasspathLine(): String {

--- a/src/main/kotlin/io/embrace/android/intellij/plugin/dataproviders/EmbraceIntegrationDataProvider.kt
+++ b/src/main/kotlin/io/embrace/android/intellij/plugin/dataproviders/EmbraceIntegrationDataProvider.kt
@@ -74,6 +74,7 @@ internal class EmbraceIntegrationDataProvider(
             startServer(callback)
         } catch (e: Exception) {
             callback.onOnboardConnectedError("Server could not be started")
+            return
         }
 
         val url = buildOnboardDashURL()

--- a/src/main/kotlin/io/embrace/android/intellij/plugin/ui/forms/EmbraceIntegrationForm.kt
+++ b/src/main/kotlin/io/embrace/android/intellij/plugin/ui/forms/EmbraceIntegrationForm.kt
@@ -201,7 +201,7 @@ internal class EmbraceIntegrationForm(
         componentManager.btnVerifyIntegration = EmbButton("btnVerifyIntegration".text()) {
             componentManager.verifyResultPanel.isVisible = false
             componentManager.btnVerifyIntegration?.isEnabled = false
-            if (dataProvider.verifyIntegration(this)) {
+            if (dataProvider.verifyIntegration(this, componentManager.getAppId())) {
                 componentManager.showLoadingPopup(it)
             }
         }.apply { isEnabled = false }
@@ -249,7 +249,10 @@ internal class EmbraceIntegrationForm(
 
     override fun onOnboardConnectedError(error: String) {
         componentManager.changeResultText(
-            componentManager.connectEmbraceResultPanel, "connectedToEmbraceError".text(), false
+            componentManager.connectEmbraceResultPanel,
+            "connectedToEmbraceError".text(),
+            success = false,
+            displaySkip = true
         )
     }
 


### PR DESCRIPTION
If the server fails to start or if there is a connection error, allow the user to skip the first step. The verification will not check for a session, but rather directly open the dashboard in a browser.